### PR TITLE
Move theme toggle to InfoBar toolbar

### DIFF
--- a/gallery-frontend/src/components/Modal/SettingModal.vue
+++ b/gallery-frontend/src/components/Modal/SettingModal.vue
@@ -38,19 +38,6 @@
             ></v-switch>
           </v-col>
         </v-row>
-        <v-row align="center" no-gutters class="mt-4" >
-          <v-col cols="auto">
-            <v-chip variant="text"> Theme </v-chip>
-          </v-col>
-          <v-col>
-            <v-switch
-              :model-value="themeIsLight"
-              @update:model-value="onThemeUpdate"
-              :disabled="!initializedStore.initialized"
-              hide-details
-            ></v-switch>
-          </v-col>
-        </v-row>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
@@ -65,12 +52,10 @@ import { computed } from 'vue'
 import { useModalStore } from '@/store/modalStore'
 import { useInitializedStore } from '@/store/initializedStore'
 import { useConstStore } from '@/store/constStore'
-import { useTheme } from 'vuetify'
 
 const modalStore = useModalStore('mainId')
 const initializedStore = useInitializedStore('mainId')
 const constStore = useConstStore('mainId')
-const vuetifyTheme = useTheme()
 
 // Read/write computed for subRowHeightScale (source of truth is constStore)
 const subRowHeightScaleValue = computed<number>({
@@ -95,22 +80,6 @@ const limitRatioValue = computed<boolean>({
   }
 })
 
-// computed boolean for light theme switch (read/write)
-const themeIsLight = computed<boolean>({
-  get: () => constStore.theme === 'light',
-  set: (newVal: boolean | null) => {
-    const wantLight = newVal ?? false
-    const newTheme = wantLight ? 'light' : 'dark'
-    constStore.updateTheme(newTheme)
-      .then(() => {
-        vuetifyTheme.global.name.value = newTheme
-      })
-      .catch((err: unknown) => {
-        console.error('Failed to update theme (via setter):', err)
-      })
-  }
-})
-
 // Handler invoked when the slider updates its model value
 const onSubRowHeightScaleUpdate = (newValue: number | null) => {
   const value = newValue ?? constStore.subRowHeightScale
@@ -127,14 +96,4 @@ const onLimitRatioUpdate = (newValue: boolean | null) => {
   })
 }
 
-const onThemeUpdate = async (newValue: boolean | null) => {
-  const wantLight = newValue ?? false
-  const newTheme = wantLight ? 'light' : 'dark'
-  try {
-    await constStore.updateTheme(newTheme)
-    vuetifyTheme.global.name.value = newTheme
-  } catch (err) {
-    console.error('Failed to update theme:', err)
-  }
-}
 </script>

--- a/gallery-frontend/src/components/NavBar/InfoBar.vue
+++ b/gallery-frontend/src/components/NavBar/InfoBar.vue
@@ -47,6 +47,13 @@
       </v-card-text>
     </v-card>
 
+    <v-btn
+      v-if="route.meta.level === 1"
+      :icon="themeIsLight ? 'mdi-weather-sunny' : 'mdi-weather-night'"
+      class="mr-2"
+      :disabled="!initializedStore.initialized"
+      @click="themeIsLight = !themeIsLight"
+    />
     <BtnCreateAlbum v-if="route.meta.level === 1" v-model="loading" />
     <v-btn
       v-if="route.meta.level === 1"
@@ -58,18 +65,39 @@
 </template>
 
 <script setup lang="ts">
-import { inject, Ref, ref, watchEffect } from 'vue'
+import { computed, inject, Ref, ref, watchEffect } from 'vue'
 import { LocationQueryValue, useRoute, useRouter } from 'vue-router'
 import { useFilterStore } from '@/store/filterStore'
 import { useUploadStore } from '@/store/uploadStore'
 import { useAlbumStore } from '@/store/albumStore'
+import { useInitializedStore } from '@/store/initializedStore'
+import { useConstStore } from '@/store/constStore'
 import BtnCreateAlbum from '@Menu/MenuButton/BtnCreateAlbum.vue'
+import { useTheme } from 'vuetify'
 
 const showDrawer = inject('showDrawer')
 
 const albumStore = useAlbumStore('mainId')
 const uploadStore = useUploadStore('mainId')
 const filterStore = useFilterStore('mainId')
+const initializedStore = useInitializedStore('mainId')
+const constStore = useConstStore('mainId')
+const vuetifyTheme = useTheme()
+
+const themeIsLight = computed<boolean>({
+  get: () => constStore.theme === 'light',
+  set: (newVal: boolean | null) => {
+    const wantLight = newVal ?? false
+    const newTheme = wantLight ? 'light' : 'dark'
+    constStore.updateTheme(newTheme)
+      .then(() => {
+        vuetifyTheme.global.name.value = newTheme
+      })
+      .catch((err: unknown) => {
+        console.error('Failed to update theme (via InfoBar):', err)
+      })
+  }
+})
 
 const route = useRoute()
 const router = useRouter()


### PR DESCRIPTION
## Summary
- move the theme toggle from the settings modal into the InfoBar toolbar
- provide a toolbar button that mirrors the previous toggle behavior and respects initialization state
- clean up the settings modal now that the theme control lives in the toolbar

## Testing
- npm install *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dceb02a2d8832e86287033b3c9e3a8